### PR TITLE
Removed returning from customers table tests for order type.

### DIFF
--- a/models/marts/__models.yml
+++ b/models/marts/__models.yml
@@ -26,7 +26,7 @@ models:
         description: Options are 'new' or 'returning', indicating if a customer has ordered more than once or has only placed their first order to date.
         tests:
           - accepted_values:
-              values: ['new', 'returning']
+              values: ['new']
 
   - name: orders
     description: Order overview data mart, offering key details for each order inlcluding if it's a customer's first order and a food vs. drink item breakdown. One row per order.


### PR DESCRIPTION
Removed returning from the accepted values for the customer type column in the orders table tests. 